### PR TITLE
fix: deduplicate snow alerts by text content, not version

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,3 +1,3 @@
 {
-  "lastSnowEmergencyVersion": "2522324.0"
+  "lastSnowEmergencyText": null
 }

--- a/cron.ts
+++ b/cron.ts
@@ -35,7 +35,7 @@ export async function checkSnowEmergency(): Promise<void> {
     expireDate: active.expireDate,
   });
 
-  if (active.version === db.data.lastSnowEmergencyVersion) {
+  if (active.text === db.data.lastSnowEmergencyText) {
     logger.info("decision: already posted, skipping", {
       ...ctx,
       version: active.version,
@@ -49,7 +49,7 @@ export async function checkSnowEmergency(): Promise<void> {
 
   await sendWebhook(message);
 
-  db.data.lastSnowEmergencyVersion = active.version;
+  db.data.lastSnowEmergencyText = active.text;
   await db.write();
 
   logger.info("decision: posted snow emergency update", {

--- a/snow.ts
+++ b/snow.ts
@@ -24,11 +24,11 @@ export type ActiveNotice = {
 };
 
 export type CronData = {
-  lastSnowEmergencyVersion: string | null;
+  lastSnowEmergencyText: string | null;
 };
 
 export const db = await JSONFilePreset<CronData>("cron.json", {
-  lastSnowEmergencyVersion: null,
+  lastSnowEmergencyText: null,
 });
 
 export async function fetchActiveNotice(): Promise<ActiveNotice | null> {

--- a/tools/snow.ts
+++ b/tools/snow.ts
@@ -22,7 +22,7 @@ export const snowEmergencyTool = tool({
       message: active.text,
       publishDate: active.publishDate,
       expireDate: active.expireDate,
-      lastNotifiedVersion: db.data.lastSnowEmergencyVersion,
+      lastNotifiedText: db.data.lastSnowEmergencyText,
       moreInfo: PARKING_URL,
     };
   },


### PR DESCRIPTION
## Summary

- Snow emergency deduplication was keyed on `version`, which encodes the publish date — so a re-published notice with identical text would still trigger a Discord post
- Now compares and stores `active.text` instead, so reposts are suppressed when the content hasn't changed
- Updated `tools/snow.ts` (used by the bot's `get_snow_emergency` tool) to reference the renamed field

Closes #19